### PR TITLE
Generate Boolean getX getters rather than isX getters

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/AbstractJavaCodegen.java
@@ -1275,7 +1275,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
      * @return getter name based on naming convention
      */
     public String toBooleanGetter(String name) {
-        return "is" + getterAndSetterCapitalize(name);
+        return "get" + getterAndSetterCapitalize(name);
     }
 
     @Override

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/java/JavaModelTest.java
@@ -715,7 +715,7 @@ public class JavaModelTest {
         Assert.assertEquals(cp.baseType, "Boolean");
         Assert.assertTrue(cp.isNotContainer);
         Assert.assertTrue(cp.isBoolean);
-        Assert.assertEquals(cp.getter, "isProperty");
+        Assert.assertEquals(cp.getter, "getProperty");
     }
 
 }


### PR DESCRIPTION
For Tapestry compatibility so models can be used directly in Forms
