### PR TITLE
Added dependency management block. Using okhttp by default.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/ApiClient.mustache
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.datatype.threetenbp.ThreeTenModule;
 {{/threetenbp}}
 
 import feign.Feign;
+import feign.okhttp.OkHttpClient;
 import feign.RequestInterceptor;
 import feign.form.FormEncoder;
 import feign.jackson.JacksonDecoder;
@@ -44,6 +45,7 @@ public class ApiClient {
     objectMapper = createObjectMapper();
     apiAuthorizations = new LinkedHashMap<String, RequestInterceptor>();
     feignBuilder = Feign.builder()
+                .client(new OkHttpClient())
                 .encoder(new FormEncoder(new JacksonEncoder(objectMapper)))
                 .decoder(new JacksonDecoder(objectMapper))
                 .logger(new Slf4jLogger());

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/pom.mustache
@@ -14,6 +14,14 @@
         <url>{{scmUrl}}</url>
     </scm>
 
+    <distributionManagement>
+        <repository>
+            <id>central</id>
+            <name>scoffable-releases</name>
+            <url>https://scoffable.jfrog.io/scoffable/libs-release-local</url>
+        </repository>
+    </distributionManagement>
+
     <licenses>
         <license>
             <name>{{licenseName}}</name>
@@ -210,6 +218,11 @@
             <version>${feign-version}</version>
         </dependency>
         <dependency>
+            <groupId>io.github.openfeign</groupId>
+            <artifactId>feign-okhttp</artifactId>
+            <version>${feign-version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.github.openfeign.form</groupId>
             <artifactId>feign-form</artifactId>
             <version>${feign-form-version}</version>
@@ -231,6 +244,7 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson-version}</version>
         </dependency>
+
         {{#withXml}}
 
             <!-- XML Support -->


### PR DESCRIPTION
Dependency management block is required for a `mvn deploy` connector library push to artifactory.

Using OkHttp as it seems a lot better for our needs (by default some sort of `sun.` package is used with `HttpUrlConnection`, and annoyingly this doesn't support PATCH requests so isn't really fit for purpose).