### PR TITLE
Fixing date parsing problem on Javascript template.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/ApiClient.mustache
@@ -513,7 +513,7 @@
    * @returns {Date} The parsed date object.
    */
 {{/emitJSDoc}}  exports.parseDate = function(str) {
-    return new Date(str.replace(/T/i, ' '));
+    return new Date(str);
   };
 
 {{#emitJSDoc}}  /**


### PR DESCRIPTION
Fixing a problem with Javascript Date parsing in the JS template. For some reason, the 'T' in the ISO 8601 formatted date was being stripped out and replaced with a space. This has been fixed so as not to happen, and now dates are correctly handled across multiple different browsers (previously, Safari and IE wouldn't support the modified ISO format).