### PR TITLE
Javascript template now returns date as string

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Javascript/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Javascript/ApiClient.mustache
@@ -539,7 +539,7 @@
       case 'String':
         return String(data);
       case 'Date':
-        return this.parseDate(String(data));
+        return String(data);
       case 'Blob':
       	return data;
       default:


### PR DESCRIPTION
Now returns dates as strings in the JS template. This it to avoid date parsing issues in browsers such as Safari and IE. Also avoids JS issues with timezones. Dates can then be parsed using more sophisticated libraries in the clients themselves.