### PR TITLE
Adding default objectmapper into JacksonDecoder constructor

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/ApiClient.mustache
@@ -62,7 +62,7 @@ public class ApiClient {
 							return new Decoder.Default().decode(pResponse, pType);
 						}
 						else {
-							return new JacksonDecoder().decode(pResponse, pType);
+							return new JacksonDecoder(objectMapper).decode(pResponse, pType);
 						}
 					}
 				})


### PR DESCRIPTION
This was accidentally changed in https://github.com/scoffable/swagger-codegen/pull/4