### PR TITLE
Improving Hystrix Error Handling in APIClient for Java Code Generation

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/ApiClient.mustache
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.netflix.hystrix.HystrixCommand;
 import com.netflix.hystrix.HystrixCommandGroupKey;
 import com.netflix.hystrix.HystrixCommandKey;
+import com.netflix.hystrix.exception.HystrixBadRequestException;
 import com.netflix.hystrix.HystrixCommand.Setter;
 {{#java8}}
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -40,6 +41,7 @@ import feign.Response;
 import feign.Target;
 import feign.codec.DecodeException;
 import feign.codec.Decoder;
+import feign.codec.ErrorDecoder;
 import feign.form.FormEncoder;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/ApiClient.mustache
@@ -56,26 +56,44 @@ public class ApiClient {
   private Map<String, RequestInterceptor> apiAuthorizations;
   private Feign.Builder feignBuilder;
 
-    public ApiClient() {
+  public ApiClient() {
       objectMapper = createObjectMapper();
       apiAuthorizations = new LinkedHashMap<String, RequestInterceptor>();
       feignBuilder = HystrixFeign.builder()
                   .client(new OkHttpClient())
                   .encoder(new FormEncoder(new JacksonEncoder(objectMapper)))
                   .decoder(new Decoder() {
-  					@Override
-  					public Object decode(Response pResponse, Type pType) throws IOException, DecodeException, FeignException {
-  						if (pType.getTypeName().equals("byte[]")) {
-  							return new Decoder.Default().decode(pResponse, pType);
-  						}
-  						else {
-  							return new JacksonDecoder(objectMapper).decode(pResponse, pType);
-  						}
-  					}
-  				})
+                	  @Override
+                	  public Object decode(Response pResponse, Type pType) throws IOException, DecodeException, FeignException {
+                		  if (pType.getTypeName().equals("byte[]")) {
+                			  return new Decoder.Default().decode(pResponse, pType);
+                		  }
+                		  else {
+							return new JacksonDecoder(objectMapper).decode(pResponse, pType);
+                		  }
+                	  }
+  					})
+                  .errorDecoder(new ErrorDecoder() {
+					@Override
+					public Exception decode(String methodKey, Response response) {
+						
+						Exception defaultException = new ErrorDecoder.Default().decode(methodKey, response);
+						
+						// If we have a response code in the 4XX range then we want to wrap our Exception in a 
+						// HystrixBadRequestException to pass through Hystrix without triggering circuit breakers and adding to
+						// Hystrix statistics
+						if (response.status() >= 400 && response.status() <= 499) {
+							return new HystrixBadRequestException("Bad Request Exception", defaultException);
+						}
+						
+						// Otherwise, normal behaviour
+						return defaultException;
+					}
+                  })
   				.setterFactory(getSetterFactory())
-                  .logger(new Slf4jLogger());
+                .logger(new Slf4jLogger());
     }
+
 
   private SetterFactory getSetterFactory() {
   return new SetterFactory() {


### PR DESCRIPTION
We noticed an issue with our current generated connector libraries where API errors in the 4XX range (400, 404, etc) are actually contributing to the statistics used by Hystrix to trigger it's circuit breakers etc. This isn't ideal as it effectively means that endpoints can be blocked by user activity - rather than just by server errors.

For example, a user continually submitting login requests with an invalid password would eventually trigger the circuit breaker for that endpoint, meaning that no other user could log in while this was happening. Now, in some ways this gives us some kind of protection from bots etc but is also just wrong, and any rate limiting should be done independently and not as a byproduct of Hystrix error handling - which can be unpredictable and has server wide consequences.

These changes fix this issue by returning HystrixBadRequestException instances for errors in the 4XX range. The HystrixBadRequestException is a special type of Hystrix exception that passes through Hystrix without triggering any circuit breakers etc. This is done by configuring the Feign connection client with a custom Error handler (see [here](https://stackoverflow.com/questions/42730881/how-do-you-allow-400-errors-to-propagate-when-using-feign-with-hystrix) for the inspiration on how this can be done.

These changes do have consequences for our public APIs and websites - any Java client that uses generated connectors to our APIs and explicitly catches HystrixRuntimeExceptions will need to be updated to handle generic Exceptions. The HystrixExceptionTools class in Scoffable-Common-Tools has been updated (https://github.com/scoffable/scoffable-common-tools/pull/20) to expect a generic exception and provides a consistent way of dealing with the responses from various Hystrix Exceptions (HystrixRuntimeException, HystrixBadRequestException etc).

My intention here is to change scoffable-api-core-public first (as that's where the issue was noticed), ensure that works, and then update all other Java packages that use our API connectors.

I am not sure if this will affect the Android API libraries - @sandyscoffable will know.

