### PR TITLE
Don't specify headers as method variables

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/api.mustache
@@ -57,7 +57,7 @@ public interface {{classname}} {
   {{/formParams}}  
   @{{httpMethod}}("{{{path}}}")
   {{^doNotUseRx}}Observable{{/doNotUseRx}}{{#doNotUseRx}}Call{{/doNotUseRx}}<{{#isResponseFile}}ResponseBody{{/isResponseFile}}{{^isResponseFile}}{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Object{{/returnType}}{{/isResponseFile}}> {{operationId}}({{^allParams}});{{/allParams}}
-    {{#allParams}}{{>libraries/retrofit2/queryParams}}{{>libraries/retrofit2/pathParams}}{{>libraries/retrofit2/headerParams}}{{>libraries/retrofit2/bodyParams}}{{>libraries/retrofit2/formParams}}{{#hasMore}}, {{/hasMore}}{{^hasMore}}
+    {{#allParams}}{{>libraries/retrofit2/queryParams}}{{>libraries/retrofit2/pathParams}}{{#generateHeaderParams}}{{>libraries/retrofit2/headerParams}}{{/generateHeaderParams}}{{>libraries/retrofit2/bodyParams}}{{>libraries/retrofit2/formParams}}{{#hasMore}}, {{/hasMore}}{{^hasMore}}
   );{{/hasMore}}{{/allParams}}
 
   {{/operation}}

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/api.mustache
@@ -32,9 +32,8 @@ public interface {{classname}} {
   /**
    * {{summary}}
    * {{notes}}
-{{#allParams}}
-   * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
-{{/allParams}}
+{{#allParams}}{{^isHeaderParam}}* @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
+   {{/isHeaderParam}}{{/allParams}}
    * @return Call&lt;{{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Object{{/returnType}}&gt;
 {{#externalDocs}}
    * {{description}}
@@ -54,11 +53,13 @@ public interface {{classname}} {
   })
   {{/-first}}
   {{/prioritizedContentTypes}}
-  {{/formParams}}  
+  {{/formParams}}
   @{{httpMethod}}("{{{path}}}")
-  {{^doNotUseRx}}Observable{{/doNotUseRx}}{{#doNotUseRx}}Call{{/doNotUseRx}}<{{#isResponseFile}}ResponseBody{{/isResponseFile}}{{^isResponseFile}}{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Object{{/returnType}}{{/isResponseFile}}> {{operationId}}({{^allParams}});{{/allParams}}
-    {{#allParams}}{{>libraries/retrofit2/queryParams}}{{>libraries/retrofit2/pathParams}}{{#generateHeaderParams}}{{>libraries/retrofit2/headerParams}}{{/generateHeaderParams}}{{>libraries/retrofit2/bodyParams}}{{>libraries/retrofit2/formParams}}{{#hasMore}}, {{/hasMore}}{{^hasMore}}
-  );{{/hasMore}}{{/allParams}}
+  {{^doNotUseRx}}Observable{{/doNotUseRx}}{{#doNotUseRx}}Call{{/doNotUseRx}}<{{#isResponseFile}}ResponseBody{{/isResponseFile}}{{^isResponseFile}}{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Object{{/returnType}}{{/isResponseFile}}> {{operationId}}(
+    {{#pathParams}}{{>libraries/retrofit2/pathParams}}{{#hasMore}}, {{/hasMore}}{{/pathParams}}
+    {{#hasBodyParam}}{{#hasPathParams}}, {{/hasPathParams}}{{/hasBodyParam}}{{#bodyParams}}{{>libraries/retrofit2/bodyParams}}{{#hasMore}}, {{/hasMore}}{{/bodyParams}}
+    {{#hasQueryParams}}{{#hasPathParams}}, {{/hasPathParams}}{{^hasPathParams}}{{#hasBodyParam}}, {{/hasBodyParam}}{{/hasPathParams}}{{/hasQueryParams}}{{#queryParams}}{{>libraries/retrofit2/queryParams}}{{#hasMore}}, {{/hasMore}}{{/queryParams}}
+  );
 
   {{/operation}}
 }


### PR DESCRIPTION
We shouldn't require headers as client method variables (these are just supplied all the time).

This screenshot should explain all:
<img width="479" alt="screenshot 2018-12-10 at 14 44 54" src="https://user-images.githubusercontent.com/20515901/49741029-6c28c680-fc8d-11e8-8066-2dbcaa329347.png">

I also ditched formParams as we aren't using them, and it was easier.