### PR TITLE
Swift updates

### DIFF
--- a/modules/swagger-codegen/src/main/resources/swift3/APIs.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/APIs.mustache
@@ -42,12 +42,6 @@ open class RequestBuilder<T> {
 
     required public init(method: String, URLString: String, parameters: Any?, isBody: Bool, headers: [String:String] = [:]) {
         self.method = method
-
-        // This fixes a problem we have discovered with Apple's URL Encoding where plus characters are not URL encoded
-        // and end up as spaces on the server. See here: https://developer.apple.com/documentation/foundation/nsurlcomponents/1407752-queryitems
-        // The following ensures that plus signs are also encoded.
-        let allowedCharacters = CharacterSet(charactersIn: "+").inverted
-        self.URLString = URLString.addingPercentEncoding(withAllowedCharacters: allowedCharacters) ?? URLString
         self.URLString = URLString
         self.parameters = parameters
         self.isBody = isBody

--- a/modules/swagger-codegen/src/main/resources/swift3/APIs.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/APIs.mustache
@@ -42,6 +42,12 @@ open class RequestBuilder<T> {
 
     required public init(method: String, URLString: String, parameters: Any?, isBody: Bool, headers: [String:String] = [:]) {
         self.method = method
+
+        // This fixes a problem we have discovered with Apple's URL where plus characters are not URL encoded
+        // and end up as spaces on the server. See here: https://developer.apple.com/documentation/foundation/nsurlcomponents/1407752-queryitems
+        // The following ensures that plus signs are also encoded.
+        let allowedCharacters = CharacterSet(charactersIn: "+").inverted
+        self.URLString = URLString.addingPercentEncoding(withAllowedCharacters: allowedCharacters) ?? URLString
         self.URLString = URLString
         self.parameters = parameters
         self.isBody = isBody

--- a/modules/swagger-codegen/src/main/resources/swift3/APIs.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/APIs.mustache
@@ -43,7 +43,7 @@ open class RequestBuilder<T> {
     required public init(method: String, URLString: String, parameters: Any?, isBody: Bool, headers: [String:String] = [:]) {
         self.method = method
 
-        // This fixes a problem we have discovered with Apple's URL where plus characters are not URL encoded
+        // This fixes a problem we have discovered with Apple's URL Encoding where plus characters are not URL encoded
         // and end up as spaces on the server. See here: https://developer.apple.com/documentation/foundation/nsurlcomponents/1407752-queryitems
         // The following ensures that plus signs are also encoded.
         let allowedCharacters = CharacterSet(charactersIn: "+").inverted

--- a/modules/swagger-codegen/src/main/resources/swift3/Podspec.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift3/Podspec.mustache
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.source_files = '{{projectName}}/Classes/**/*.swift'{{#usePromiseKit}}
   s.dependency 'PromiseKit/CorePromise', '~> 4.4.0'{{/usePromiseKit}}{{#useRxSwift}}
   s.dependency 'RxSwift', '3.6.1'{{/useRxSwift}}
-  s.dependency 'Alamofire', '~> 4.5.0'
+  s.dependency 'Alamofire', '~> 4.8.0'
 end

--- a/modules/swagger-codegen/src/main/resources/swift4/APIs.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift4/APIs.mustache
@@ -26,7 +26,11 @@ open class RequestBuilder<T> {
 
     required public init(method: String, URLString: String, parameters: [String:Any]?, isBody: Bool, headers: [String:String] = [:]) {
         self.method = method
-        self.URLString = URLString
+        // This fixes a problem we have discovered with Apple's URL Encoding where plus characters are not URL encoded
+        // and end up as spaces on the server. See here: https://developer.apple.com/documentation/foundation/nsurlcomponents/1407752-queryitems
+        // The following ensures that plus signs are also encoded.
+        let allowedCharacters = CharacterSet(charactersIn: "+").inverted
+        self.URLString = URLString.addingPercentEncoding(withAllowedCharacters: allowedCharacters) ?? URLString
         self.parameters = parameters
         self.isBody = isBody
         self.headers = headers

--- a/modules/swagger-codegen/src/main/resources/swift4/Podspec.mustache
+++ b/modules/swagger-codegen/src/main/resources/swift4/Podspec.mustache
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.source_files = '{{projectName}}/Classes/**/*.swift'{{#usePromiseKit}}
   s.dependency 'PromiseKit/CorePromise', '~> 4.4.0'{{/usePromiseKit}}{{#useRxSwift}}
   s.dependency 'RxSwift', '~> 4.0'{{/useRxSwift}}
-  s.dependency 'Alamofire', '~> 4.5.0'
+  s.dependency 'Alamofire', '~> 4.8.0'
 end


### PR DESCRIPTION
Fixes up an issue where Apple's URL encoding tools don't URL encode plus characters. This breaks our email checking service when plus chars are included in the email address. The following change to the Swift template fixes this specifically in the case of + chars (all other chars are encoded by default). Apparently this is a "feature" rather than a bug.

See here for more info: https://developer.apple.com/documentation/foundation/nsurlcomponents/1407752-queryitems

Also updates the Alamo Fire version.