### PR TITLE
Fixing issues with missing maven build plugin and hystrix version

### DIFF
--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/pom.mustache
@@ -112,6 +112,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>add_sources</id>
@@ -309,10 +310,15 @@
             <version>1.7.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.netflix.hystrix</groupId>
+            <artifactId>hystrix-core</artifactId>
+            <version>1.5.18</version>
+        </dependency>
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}</java.version>
+        <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <swagger-core-version>1.5.15</swagger-core-version>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/google-api-client/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/google-api-client/pom.mustache
@@ -104,7 +104,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.10</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>add_sources</id>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/pom.mustache
@@ -104,6 +104,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>add_sources</id>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
@@ -104,7 +104,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.10</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>add_sources</id>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resteasy/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resteasy/pom.mustache
@@ -85,6 +85,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>add_sources</id>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/resttemplate/pom.mustache
@@ -104,7 +104,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.10</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>add_sources</id>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit/pom.mustache
@@ -104,6 +104,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>add_sources</id>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/retrofit2/pom.mustache
@@ -104,7 +104,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.10</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>add_sources</id>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/vertx/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/vertx/pom.mustache
@@ -104,7 +104,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>add_sources</id>

--- a/modules/swagger-codegen/src/main/resources/Java/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/pom.mustache
@@ -104,7 +104,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.10</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>add_sources</id>
@@ -319,6 +319,11 @@
             <artifactId>junit</artifactId>
             <version>${junit-version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.netflix.hystrix</groupId>
+            <artifactId>hystrix-core</artifactId>
+            <version>1.5.18</version>
         </dependency>
     </dependencies>
     <properties>

--- a/modules/swagger-codegen/src/main/resources/JavaInflector/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaInflector/pom.mustache
@@ -48,7 +48,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.10</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>add-source</id>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf-cdi/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf-cdi/pom.mustache
@@ -15,7 +15,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.9.1</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>add-source</id>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/pom.mustache
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>1.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>add-source</id>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>1.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>add-source</id>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/libraries/jersey1/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/libraries/jersey1/pom.mustache
@@ -66,7 +66,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>1.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>add-source</id>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/pom.mustache
@@ -75,7 +75,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>1.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>add-source</id>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/eap/pom.mustache
@@ -38,7 +38,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.9.1</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>add-source</id>

--- a/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaJaxRS/resteasy/pom.mustache
@@ -38,7 +38,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.9.1</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>add-source</id>

--- a/modules/swagger-codegen/src/main/resources/MSF4J/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/MSF4J/pom.mustache
@@ -27,7 +27,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>1.9.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>add-source</id>

--- a/modules/swagger-codegen/src/main/resources/akka-scala/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/akka-scala/pom.mustache
@@ -170,7 +170,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>add_sources</id>

--- a/modules/swagger-codegen/src/main/resources/android/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/android/pom.mustache
@@ -85,6 +85,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>add_sources</id>

--- a/modules/swagger-codegen/src/main/resources/codegen/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/codegen/pom.mustache
@@ -65,6 +65,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>add_sources</id>

--- a/modules/swagger-codegen/src/main/resources/scala/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/scala/pom.mustache
@@ -89,7 +89,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.9.1</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>add_sources</id>

--- a/modules/swagger-codegen/src/test/resources/2_0/templates/Java/libraries/jersey2/pom.mustache
+++ b/modules/swagger-codegen/src/test/resources/2_0/templates/Java/libraries/jersey2/pom.mustache
@@ -106,6 +106,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>add_sources</id>


### PR DESCRIPTION
We've been seeing maven warning about no version for the build-helper-maven-plugin, so fixing this across the board in Swagger codegen. I know we only really use one of these templates, but it's wrong all over the place so changing.

Also fixing the version of hystrix to a none broken one. There is also some config for Java 7 / 8 that we don't use and means that our connectors always default to Java 7. This isn't really a big deal, but fixing here anyway so that it's fixed to Java 8 for our purposes.