### PR TITLE
Move package repository from JFrog to Github Packages

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -1,13 +1,10 @@
 package io.swagger.codegen.languages;
 
-import static java.util.Collections.sort;
-
 import com.google.common.collect.LinkedListMultimap;
 import io.swagger.codegen.*;
 import io.swagger.codegen.languages.features.BeanValidationFeatures;
 import io.swagger.codegen.languages.features.GzipFeatures;
 import io.swagger.codegen.languages.features.PerformBeanValidationFeatures;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -16,6 +13,8 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.*;
 import java.util.regex.Pattern;
+
+import static java.util.Collections.sort;
 
 public class JavaClientCodegen extends AbstractJavaCodegen
         implements BeanValidationFeatures, PerformBeanValidationFeatures,
@@ -211,6 +210,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
             additionalProperties.put("jackson", "true");
             supportingFiles.add(new SupportingFile("ParamExpander.mustache", invokerFolder, "ParamExpander.java"));
             supportingFiles.add(new SupportingFile("EncodingUtils.mustache", invokerFolder, "EncodingUtils.java"));
+            supportingFiles.add(new SupportingFile("maven-publish.yml.mustache", ".github/workflows", "maven-publish.yml"));
         } else if ("okhttp-gson".equals(getLibrary()) || StringUtils.isEmpty(getLibrary())) {
             // the "okhttp-gson" library template requires "ApiCallback.mustache" for async call
             supportingFiles.add(new SupportingFile("ApiCallback.mustache", invokerFolder, "ApiCallback.java"));

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/maven-publish.yml.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/maven-publish.yml.mustache
@@ -1,0 +1,33 @@
+name: Maven Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+      - name: Maven publish to GitHub Packages
+        run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,author # selectable (default: repo,message)
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+        if: failure()

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/feign/pom.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/feign/pom.mustache
@@ -14,13 +14,13 @@
         <url>{{scmUrl}}</url>
     </scm>
 
-    <distributionManagement>
-        <repository>
-            <id>central</id>
-            <name>scoffable-releases</name>
-            <url>https://scoffable.jfrog.io/scoffable/libs-release-local</url>
-        </repository>
-    </distributionManagement>
+	<distributionManagement>
+	   <repository>
+	     <id>github</id>
+	     <name>GitHub Scoffable Apache Maven Packages</name>
+	     <url>https://maven.pkg.github.com/scoffable/${artifactId}</url>
+	   </repository>
+	</distributionManagement>
 
     <licenses>
         <license>


### PR DESCRIPTION
We've decided to move package repository (JFrog is rubbish and also costs an arm and a leg).

This change updates our connectors generation code to build connectors which by default push to GitHub, and also have a GitHub Action that packages the connector when it's tagged (as per all our other modules that aren't connectors).