### PR TITLE
Added GHA workflow to build JAR file

### DIFF
--- a/.github/workflows/build-and-commit-jar.yml
+++ b/.github/workflows/build-and-commit-jar.yml
@@ -1,0 +1,32 @@
+# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java#apache-maven-with-a-settings-path
+
+name: scoffable-api-deltrack-public pull request
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  connector-gen:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.AUTOMATION_REPO_ACCESS_TOKEN }}
+
+      - name: Build JAR
+        run: |
+          mvn clean package -DskipTests
+
+      - name: Copy JAR to root directory
+        run: |
+          cp modules/swagger-codegen-cli/target/swagger-codegen-cli.jar .
+
+      - name: Commit updated connectors (if needed)
+        if: github.actor != 'scoffableautomation' # If this run was already triggered by an automated commit, this avoids a potential infinite loop
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Regenerated Swagger CLI

--- a/.github/workflows/build-and-commit-jar.yml
+++ b/.github/workflows/build-and-commit-jar.yml
@@ -25,8 +25,8 @@ jobs:
         run: |
           cp -f modules/swagger-codegen-cli/target/swagger-codegen-cli.jar .
 
-      - name: Commit updated connectors (if needed)
+      - name: Commit updated JAR file
         if: github.actor != 'scoffableautomation' # If this run was already triggered by an automated commit, this avoids a potential infinite loop
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: Regenerated Swagger CLI
+          commit_message: Regenerated Swagger CLI JAR

--- a/.github/workflows/build-and-commit-jar.yml
+++ b/.github/workflows/build-and-commit-jar.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.AUTOMATION_REPO_ACCESS_TOKEN }}
+          token: ${{ secrets.SWAGGER_CODEGEN_REPO_ACCESS_TOKEN }}
 
       - name: Build JAR
         run: |

--- a/.github/workflows/build-and-commit-jar.yml
+++ b/.github/workflows/build-and-commit-jar.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - master
 jobs:
-  connector-gen:
+  build-and-commit-cli-jar:
     timeout-minutes: 15
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build-and-commit-jar.yml
+++ b/.github/workflows/build-and-commit-jar.yml
@@ -1,7 +1,7 @@
 # This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
 # For more information see: https://github.com/actions/setup-java#apache-maven-with-a-settings-path
 
-name: scoffable-api-deltrack-public pull request
+name: Rebuild CLI JAR file
 on:
   pull_request:
     branches:
@@ -23,7 +23,7 @@ jobs:
 
       - name: Copy JAR to root directory
         run: |
-          cp modules/swagger-codegen-cli/target/swagger-codegen-cli.jar .
+          cp -f modules/swagger-codegen-cli/target/swagger-codegen-cli.jar .
 
       - name: Commit updated connectors (if needed)
         if: github.actor != 'scoffableautomation' # If this run was already triggered by an automated commit, this avoids a potential infinite loop


### PR DESCRIPTION
So other Scoffable projects can use our custom (ancient) connector generation code, without having to directly build this project.

I really couldn't be bothered figuring out maven deployment of this, so it's literally just committing the built JAR file into the root directory.